### PR TITLE
Add order id generation + order retrieval

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -17,6 +17,13 @@ server.use(morgan("dev"));
 //parse json bodies
 server.use(express.json());
 
+//add cors allow origin header after response is set
+server.use((req, resp, next) => {
+	next();
+
+	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
+});
+
 //static directory is accessible as /static/ and loads files from ./public
 server.use("/static/", express.static("./public/"));
 
@@ -54,28 +61,24 @@ server.get("/", (req, resp) => {
 
 server.get("/apps", async (req, resp) => {
 	let data = JSON.parse(await fs.readFile("./data/new_apps"));
-	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);
 });
 
 server.get("/foods", async (req, resp) => {
 	let data = JSON.parse(await fs.readFile("./data/new_foods"));
-	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);
 });
 
 server.get("/restaurants", async (req, resp) => {
 	let data = JSON.parse(await fs.readFile("./data/new_restaurants"));
-	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);
 });
 
 server.post("/new_order", async (req, resp) => {
 	let data = gen_new_order();
-	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);
 });
@@ -92,7 +95,6 @@ server.get("/order/:order_id", async (req, resp) => {
 		data = {"error": "Order not found"};
 		resp.statusCode = 404;
 	}
-	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);
 });

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -20,6 +20,28 @@ server.use(express.json());
 //static directory is accessible as /static/ and loads files from ./public
 server.use("/static/", express.static("./public/"));
 
+//global variables
+
+//TODO make sure orders can only be accessed by the user who made them, when login gets implemented
+let next_order_id = 0;
+let orders = {};
+
+//this ^^^ should be avoided, but this is stopgap until mongoose -> mongodb atlas connection is made
+
+let gen_new_order = () => {
+	let order_id = next_order_id;
+	++next_order_id;
+
+	//MAGIC -1 for not defined yet
+	orders[order_id] = {
+		id: order_id,
+		restaurant_id: -1,
+		food_ids: [],
+		app_id: -1
+	};
+	return order_id;
+};
+
 server.get("/", (req, resp) => {
 	let data = {
 		"working": true,
@@ -46,6 +68,30 @@ server.get("/foods", async (req, resp) => {
 
 server.get("/restaurants", async (req, resp) => {
 	let data = JSON.parse(await fs.readFile("./data/new_restaurants"));
+	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
+
+	return resp.json(data);
+});
+
+server.post("/new_order", async (req, resp) => {
+	let data = gen_new_order();
+	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
+
+	return resp.json(data);
+});
+
+server.get("/order/:order_id", async (req, resp) => {
+	let order_id = Number(req.params.order_id);
+
+	let data;
+
+	if (orders.hasOwnProperty(order_id)){
+		data = orders[order_id];
+	}
+	else{
+		data = {"error": "Order not found"};
+		resp.statusCode = 404;
+	}
 	resp.set("Access-Control-Allow-Origin", config.frontend_base_url);
 
 	return resp.json(data);

--- a/back-end/test/request.js
+++ b/back-end/test/request.js
@@ -2,8 +2,14 @@ let assert = require("chai").assert;
 let axios = require("axios");
 
 let request_factory = (server) => {
-	return async (...args) => {
-		let resp = await axios(server.base_url + args[0], ...args.slice(1));
+	return async (endpoint, user_params) => {
+		let params = {
+			//allow all requests to succeed even if they have error status codes
+			validateStatus: (status) => true
+		};
+		params = {...params, ...user_params};
+
+		let resp = await axios(server.base_url + endpoint, params);
 		return [resp.data, resp.status];
 	};
 };

--- a/back-end/test/route/new_order.js
+++ b/back-end/test/route/new_order.js
@@ -1,0 +1,26 @@
+let {assert, request_factory} = require("../request");
+
+describe("/new_order endpoint", () => {
+	let server;
+	let request;
+
+	before((done) => {
+		server = require("../../server");
+		request = request_factory(server);
+		done();
+	});
+
+	//TODO for some reason refused to work uncommented
+	//after(() => {
+	//	server.stop();
+	//});
+
+	it("will have status code 200", async () => {
+		assert.equal(200, (await request("/new_order", {method: "POST"}))[1]);
+	});
+
+	it("will return a number", async () => {
+		let data = (await request("/new_order", {method: "POST"}))[0];
+		assert.typeOf(data, "number");
+	});
+});

--- a/back-end/test/route/order_get.js
+++ b/back-end/test/route/order_get.js
@@ -48,5 +48,9 @@ describe("/order/:order_id GET endpoint", () => {
 
 		assert.typeOf(data["app_id"], "number");
 	});
+
+	it("will have status code 404 for invalid order_id", async () => {
+		assert.equal(404, (await request("/order/invalid_id_lol"))[1]);
+	});
 });
 

--- a/back-end/test/route/order_get.js
+++ b/back-end/test/route/order_get.js
@@ -1,0 +1,52 @@
+let {assert, request_factory} = require("../request");
+
+describe("/order/:order_id GET endpoint", () => {
+	let server;
+	let request;
+	let order_id;
+
+	before((done) => {
+		server = require("../../server");
+		request = request_factory(server);
+		done();
+	});
+
+	//TODO for some reason refused to work uncommented
+	//after(() => {
+	//	server.stop();
+	//});
+
+	it("will have status code 200", async () => {
+		order_id = (await request("/new_order", {method: "POST"}))[0];
+
+		assert.equal(200, (await request(`/order/${order_id}`))[1]);
+	});
+
+	it("will return an object", async () => {
+		let data = (await request(`/order/${order_id}`))[0];
+		assert.typeOf(data, "object");
+	});
+
+	it("will have exactly the expected fields", async () => {
+		let data = (await request(`/order/${order_id}`))[0];
+		let expected_keys = ["id", "restaurant_id", "food_ids", "app_id"];
+
+		assert.hasAllKeys(data, expected_keys);
+	});
+
+	it("will have the correct types for each field", async () => {
+		let data = (await request(`/order/${order_id}`))[0];
+
+		assert.typeOf(data["id"], "number");
+
+		assert.typeOf(data["restaurant_id"], "number");
+
+		assert.typeOf(data["food_ids"], "array");
+		for (let it of data["food_ids"]){
+			assert.typeOf(it, "number");
+		}
+
+		assert.typeOf(data["app_id"], "number");
+	});
+});
+


### PR DESCRIPTION
This adds to the backend:

- order id generation
- getting an order from an order id
- a temporary in-memory list of orders (will swap to mongoose when mongodb atlas integration is done)